### PR TITLE
Allow loggers to configure Winston

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,10 @@ class Main {
         return logger;
     }
 
+    configure(options) {
+        Winston.configure(options);
+    }
+
     addTransport(options) {
         if (options.console) {
             Winston.add(Winston.transports.Console, {


### PR DESCRIPTION
`Winston.configure({...})` can be used to set a lot of useful options, one of which is `exitOnError` (which defaults to `true`, very important to know in production systems).

This PR adds a method to allow any client of `uuid-logger` to configure the underlying winston instance.